### PR TITLE
Fix notification row layout to display content of notification

### DIFF
--- a/rofication-gui.py
+++ b/rofication-gui.py
@@ -44,6 +44,8 @@ def call_rofi(entries, additional_args=[]):
                              '-markup-rows',
                              '-sep', '\\0',
                              '-format', 'i',
+                             '-eh', '2',
+                             '-lines', '10',
                              '-sidebar-mode'])
     proc = subprocess.Popen(rofi_command+ additional_args, stdin=subprocess.PIPE, stdout=subprocess.PIPE)
     for e in entries:


### PR DESCRIPTION
There is a problem where the notification pop-up does not show the body of the notification itself on the new line. Adding spacing solved the issue, hardcoding line amount ensures a proper height of the pop-up.