### PR TITLE
Do not use nominal color for default state of status icon.

### DIFF
--- a/rofication-status
+++ b/rofication-status
@@ -22,8 +22,6 @@ if __name__ == '__main__':
         num, crit = client.count()
         if num > 0:
             label_icon = resources.notify_some
-        else:
-            label_color = resources.nominal_color
         if crit > 0:
             value_color = resources.critical_color
     except (FileNotFoundError, ConnectionRefusedError):


### PR DESCRIPTION
A small change to use the label (aka icon) color for the default state of the rofication icon.  

Before change:
![rofication-before](https://user-images.githubusercontent.com/49683/81371228-28b5d000-90ac-11ea-9718-3762d7d8b7c8.png)

After change:
![rofication-after](https://user-images.githubusercontent.com/49683/81371242-2f444780-90ac-11ea-8f50-d781dec0ac4c.png)

My reasoning here is that the default (good) state of a status icon should use the label color to blend in.  the nominal color stands out brightly with themes of less contrast.