### PR TITLE
Use i3xrocks.warning for label color if there are notifications

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+regolith-rofication (1.2.2-1) focal; urgency=medium
+
+  * i3xrocks.warning now used for value color if there are non-critical notifications.
+
+ -- Regolith Linux <regolith.linux@gmail.com>  Fri 08 May 2020 08:16:50 -0700
+
 regolith-rofication (1.2.1-1) focal; urgency=medium
 
   * Package adjustment to color of icon under default state. 

--- a/debian/rules
+++ b/debian/rules
@@ -1,7 +1,6 @@
 #!/usr/bin/make -f
-export DH_VERBOSE=1
+#export DH_VERBOSE=1
 export PYBUILD_NAME=rofication
 
 %:
 	dh $@ --with python3 --buildsystem=pybuild
-

--- a/rofication-status
+++ b/rofication-status
@@ -22,6 +22,7 @@ if __name__ == '__main__':
         num, crit = client.count()
         if num > 0:
             label_icon = resources.notify_some
+            value_color = resources.warning_color
         if crit > 0:
             value_color = resources.critical_color
     except (FileNotFoundError, ConnectionRefusedError):

--- a/rofication/_metadata.py
+++ b/rofication/_metadata.py
@@ -1,4 +1,4 @@
 # I did not merge this file in _static to be easily parsable by the setup script
 ROFICATION_NAME = 'rofication'
 ROFICATION_URL = 'https://github.com/regolith-linux/regolith-rofication'
-ROFICATION_VERSION = '1.2.0'
+ROFICATION_VERSION = '1.2.2'

--- a/rofication/resources/__init__.py
+++ b/rofication/resources/__init__.py
@@ -1,2 +1,2 @@
 from ._static import __version__, value_font, notify_some, notify_none, notify_error, \
-    value_color, label_color, critical_color, nominal_color
+    value_color, label_color, critical_color, nominal_color, warning_color

--- a/rofication/resources/_static.py
+++ b/rofication/resources/_static.py
@@ -9,7 +9,8 @@ notify_none = Resource(env_name='i3xrocks_label_notify_none', xres_name='i3xrock
 notify_some = Resource(env_name='i3xrocks_label_notify_some', xres_name='i3xrocks.label.notify.some', default='N')
 notify_error = Resource(env_name='i3xrocks_label_notify_error', xres_name='i3xrocks.label.notify.error', default='N')
 
-value_color = Resource(env_name='color', xres_name='i3xrocks.value.color', default='#D8DEE9')
-label_color = Resource(env_name='label_color', xres_name='i3xrocks.label.color', default='#7B8394')
-nominal_color = Resource(env_name='background_color', xres_name='i3xrocks.nominal', default='#D8DEE9')
+value_color = Resource(env_name='color', xres_name='i3xrocks.value.color', default='#E6E1CF')
+label_color = Resource(env_name='label_color', xres_name='i3xrocks.label.color', default='#E6E1CF')
+nominal_color = Resource(env_name='background_color', xres_name='i3xrocks.nominal', default='#E6E1CF')
+warning_color = Resource(env_name='warn_color', xres_name='i3xrocks.warning', default='#FFD580')
 critical_color = Resource(xres_name='i3xrocks.critical.color', default='#BF616A')


### PR DESCRIPTION
Following the same reasoning of [this PR for the volume blocklet](https://github.com/regolith-linux/regolith-i3xrocks-config/pull/47), I would like to use the warning color to highlight the notification label when there are non-critical notifications.

![Screenshot from 2020-05-08 17-21-49](https://user-images.githubusercontent.com/18445221/81420593-784dd780-9150-11ea-8bb6-43dc23491c74.png)

It is non-intrusive, and helps noticing that the notification list needs attention. I will be using this for myself so I though I would share if it is wanted.