### PR TITLE
Remove debug logs that show up in /var/log/syslog

### DIFF
--- a/rofication/_client.py
+++ b/rofication/_client.py
@@ -18,12 +18,10 @@ class RoficationClient:
 
     def _send(self, command: str, arg: any) -> None:
         with self._client_socket() as sck:
-            print(f'Send: {command}:{arg}', file=self._out)
             sck.send(bytes(f'{command}:{arg}\n', encoding='utf-8'))
 
     def count(self) -> (int, int):
         with self._client_socket() as sck:
-            print('Send: num', file=self._out)
             sck.send(b'num\n')
             data = sck.recv(32).decode('utf-8')
             return (int(x) for x in data.split(',', 2))
@@ -36,7 +34,6 @@ class RoficationClient:
 
     def list(self) -> Sequence[Notification]:
         with self._client_socket() as sck:
-            print('Send: list', file=self._out)
             sck.send(b'list\n')
             with sck.makefile(mode='r', encoding='utf-8') as fp:
                 return json.load(fp, object_hook=Notification.make)


### PR DESCRIPTION

Remove debug statements.  Eg:

```bash
$ cat /var/log/syslog | grep Send
May  8 10:22:47 skade regolith.desktop[35400]: Send: list
May  8 10:22:51 skade regolith.desktop[35449]: Send: list
May  8 10:22:51 skade regolith.desktop[35449]: Send: del:1
May  8 10:22:54 skade regolith.desktop[35528]: Send: list
```