### PR TITLE
keep ui open if there are still notifications left

### DIFF
--- a/rofication/_gui.py
+++ b/rofication/_gui.py
@@ -110,6 +110,8 @@ class RoficationGui():
                 # Dismiss all notifications for application
                 elif exit_code == 13:
                     self._client.delete_all(notifications[selected].application)
-                    break
+                    # This was the last group of notifications
+                    if len(notifications) == 1:
+                        break
                 elif exit_code != 12:
                     break


### PR DESCRIPTION
When a group of notifications are deleted, it's possible that notifications are still present (e.g. other types of events). In this case, the UI should not close.

This change will still close the ui if deleting that group deletes the last remaining notifications. 