### PR TITLE
Feature: store the notification state of 'icon'

### DIFF
--- a/rofication/_dbus.py
+++ b/rofication/_dbus.py
@@ -65,6 +65,7 @@ class RoficationDbusObject(service.Object):
         notification.icon = app_icon
         notification.summary = summary
         notification.body = body
+        notification.hints = hints
         notification.actions = tuple(actions)
         if int(expire_timeout) > 0:
             notification.deadline = time.time() + expire_timeout / 1000.0

--- a/rofication/_dbus.py
+++ b/rofication/_dbus.py
@@ -62,6 +62,7 @@ class RoficationDbusObject(service.Object):
         notification = Notification()
         notification.id = replaces_id
         notification.application = app_name
+        notification.icon = app_icon
         notification.summary = summary
         notification.body = body
         notification.actions = tuple(actions)

--- a/rofication/_notification.py
+++ b/rofication/_notification.py
@@ -25,6 +25,7 @@ class Notification:
         self.icon: Optional[str] = None
         self.urgency: Urgency = Urgency.NORMAL
         self.actions: Sequence[str] = ()
+        self.hints: Mapping[str, any] = {}
 
     def asdict(self) -> Mapping[str, any]:
         return {field: value for field, value in vars(self).items() if value is not None}
@@ -40,4 +41,5 @@ class Notification:
         notification.icon = dct.get('icon')
         notification.urgency = Urgency(dct.get('urgency', Urgency.NORMAL))
         notification.actions = tuple(dct.get('actions', ()))
+        notification.hints = mapping(dct.get('hints'))
         return notification

--- a/rofication/_notification.py
+++ b/rofication/_notification.py
@@ -22,6 +22,7 @@ class Notification:
         self.summary: Optional[str] = None
         self.body: Optional[str] = None
         self.application: Optional[str] = None
+        self.icon: Optional[str] = None
         self.urgency: Urgency = Urgency.NORMAL
         self.actions: Sequence[str] = ()
 
@@ -36,6 +37,7 @@ class Notification:
         notification.summary = dct.get('summary')
         notification.body = dct.get('body')
         notification.application = dct.get('application')
+        notification.icon = dct.get('icon')
         notification.urgency = Urgency(dct.get('urgency', Urgency.NORMAL))
         notification.actions = tuple(dct.get('actions', ()))
         return notification


### PR DESCRIPTION
This change adds the freedesktop.org notification spec field `app_icon` as state that is tracked by rofication_daemon.  This is needed for a new rofication frontend in development.

## Testing Done

Ran updated server locally.  Generated a notification with `notify-send` and another with network manager by cycling my wifi connection.  Observed the following via netcat:

```bash
$ nc -U /tmp/rofi_notification_daemon
list
[{"id": 1, "summary": "boo-hoo", "body": "", "application": "notify-send", "icon": "", "urgency": 1, "actions": []}, {"id": 2, "summary": "Connection Established", "body": "You are now connected to the Wi-Fi network \u201ctsukiji\u201d.", "application": "NetworkManager", "icon": "nm-signal-75", "urgency": 0, "actions": ["disable-connected-notifications", "Don\u2019t show this message again"]}]
```
