### PR TITLE
Add timestamps to notifications

### DIFF
--- a/rofication-daemon
+++ b/rofication-daemon
@@ -2,15 +2,13 @@
 
 import argparse
 from rofication import RoficationServer, NotificationQueue, RoficationDbusService
+from rofication._util import Resource
 
 if __name__ == '__main__':
 
-    parser = argparse.ArgumentParser(description='Rofication daemon - listen to notifications on DBus and expose them to rofication.')
-    parser.add_argument('--tsformat', help='Format for the date and time to use when displaying notifications, in python strftime format. Defaults to locale format. Use "" if you don\'t want any time information', default='%x %X')
-    args = parser.parse_args()
-
+    tsformat = Resource(env_name='i3xrocks_notify_timestamp_format', xres_name='i3xrocks.notify.timestamp.format', default='').fetch()
     not_queue = NotificationQueue.load('not.json')
-    service = RoficationDbusService(not_queue, args.tsformat)
+    service = RoficationDbusService(not_queue, tsformat)
 
     with RoficationServer(not_queue) as server:
         server.start()

--- a/rofication-daemon
+++ b/rofication-daemon
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 
-import argparse
 from rofication import RoficationServer, NotificationQueue, RoficationDbusService
 from rofication._util import Resource
 

--- a/rofication-daemon
+++ b/rofication-daemon
@@ -1,11 +1,8 @@
 #!/usr/bin/env python3
 
 from rofication import RoficationServer, NotificationQueue, RoficationDbusService
-from rofication._util import Resource
 
 if __name__ == '__main__':
-
-    tsformat = Resource(env_name='i3xrocks_notify_timestamp_format', xres_name='i3xrocks.notify.timestamp.format', default='').fetch()
     not_queue = NotificationQueue.load('not.json')
     service = RoficationDbusService(not_queue)
 

--- a/rofication-daemon
+++ b/rofication-daemon
@@ -7,7 +7,7 @@ if __name__ == '__main__':
 
     tsformat = Resource(env_name='i3xrocks_notify_timestamp_format', xres_name='i3xrocks.notify.timestamp.format', default='').fetch()
     not_queue = NotificationQueue.load('not.json')
-    service = RoficationDbusService(not_queue, tsformat)
+    service = RoficationDbusService(not_queue)
 
     with RoficationServer(not_queue) as server:
         server.start()

--- a/rofication-daemon
+++ b/rofication-daemon
@@ -1,10 +1,16 @@
 #!/usr/bin/env python3
 
+import argparse
 from rofication import RoficationServer, NotificationQueue, RoficationDbusService
 
 if __name__ == '__main__':
+
+    parser = argparse.ArgumentParser(description='Rofication daemon - listen to notifications on DBus and expose them to rofication.')
+    parser.add_argument('--tsformat', help='Format for the date and time to use when displaying notifications, in python strftime format. Defaults to locale format. Use "" if you don\'t want any time information', default='%x %X')
+    args = parser.parse_args()
+
     not_queue = NotificationQueue.load('not.json')
-    service = RoficationDbusService(not_queue)
+    service = RoficationDbusService(not_queue, args.tsformat)
 
     with RoficationServer(not_queue) as server:
         server.start()

--- a/rofication/_dbus.py
+++ b/rofication/_dbus.py
@@ -15,7 +15,7 @@ NOTIFICATIONS_DBUS_OBJECT_PATH = '/org/freedesktop/Notifications'
 
 
 class RoficationDbusObject(service.Object):
-    def __init__(self, queue: NotificationQueue) -> None:
+    def __init__(self, queue: NotificationQueue, datetime_format: str = None) -> None:
         super().__init__(
             object_path=NOTIFICATIONS_DBUS_OBJECT_PATH,
             bus_name=service.BusName(
@@ -24,6 +24,7 @@ class RoficationDbusObject(service.Object):
             )
         )
         self._queue: NotificationQueue = queue
+        self._datetime_format: str = datetime_format
 
         def notification_seen(notification):
             if 'default' in notification.actions:
@@ -65,7 +66,7 @@ class RoficationDbusObject(service.Object):
         notification.application = app_name
         notification.summary = summary
         notification.body = body
-        notification.timestamp = datetime.now().strftime("%d/%m/%Y %H:%M:%S")
+        notification.timestamp = datetime.now().strftime(self._datetime_format) if self._datetime_format else ""
         notification.actions = tuple(actions)
         if int(expire_timeout) > 0:
             notification.deadline = time.time() + expire_timeout / 1000.0
@@ -77,9 +78,9 @@ class RoficationDbusObject(service.Object):
 
 
 class RoficationDbusService:
-    def __init__(self, queue: NotificationQueue) -> None:
+    def __init__(self, queue: NotificationQueue, datetime_format: str = None) -> None:
         # preserve D-Bus object reference
-        self._object = RoficationDbusObject(queue)
+        self._object = RoficationDbusObject(queue, datetime_format)
         # create GLib mainloop, this is needed to make D-Bus work and takes care of catching signals.
         self._loop = MainLoop()
 

--- a/rofication/_dbus.py
+++ b/rofication/_dbus.py
@@ -66,6 +66,7 @@ class RoficationDbusObject(service.Object):
         notification.application = app_name
         notification.summary = summary
         notification.body = body
+        notification.hints = hints
         notification.timestamp = datetime.now().strftime(self._datetime_format) if self._datetime_format else ""
         notification.actions = tuple(actions)
         if int(expire_timeout) > 0:

--- a/rofication/_dbus.py
+++ b/rofication/_dbus.py
@@ -8,6 +8,7 @@ from gi.repository.GLib import MainLoop
 from ._metadata import ROFICATION_VERSION, ROFICATION_NAME, ROFICATION_URL
 from ._notification import Notification, Urgency
 from ._queue import NotificationQueue
+from datetime import datetime
 
 NOTIFICATIONS_DBUS_INTERFACE = 'org.freedesktop.Notifications'
 NOTIFICATIONS_DBUS_OBJECT_PATH = '/org/freedesktop/Notifications'
@@ -64,6 +65,7 @@ class RoficationDbusObject(service.Object):
         notification.application = app_name
         notification.summary = summary
         notification.body = body
+        notification.timestamp = datetime.now().strftime("%d/%m/%Y %H:%M:%S")
         notification.actions = tuple(actions)
         if int(expire_timeout) > 0:
             notification.deadline = time.time() + expire_timeout / 1000.0

--- a/rofication/_dbus.py
+++ b/rofication/_dbus.py
@@ -15,7 +15,7 @@ NOTIFICATIONS_DBUS_OBJECT_PATH = '/org/freedesktop/Notifications'
 
 
 class RoficationDbusObject(service.Object):
-    def __init__(self, queue: NotificationQueue, datetime_format: str = None) -> None:
+    def __init__(self, queue: NotificationQueue) -> None:
         super().__init__(
             object_path=NOTIFICATIONS_DBUS_OBJECT_PATH,
             bus_name=service.BusName(
@@ -24,7 +24,6 @@ class RoficationDbusObject(service.Object):
             )
         )
         self._queue: NotificationQueue = queue
-        self._datetime_format: str = datetime_format
 
         def notification_seen(notification):
             if 'default' in notification.actions:
@@ -68,7 +67,7 @@ class RoficationDbusObject(service.Object):
         notification.summary = summary
         notification.body = body
         notification.hints = hints
-        notification.timestamp = datetime.now().strftime(self._datetime_format) if self._datetime_format else ""
+        notification.timestamp = datetime.now().timestamp()
         notification.actions = tuple(actions)
         if int(expire_timeout) > 0:
             notification.deadline = time.time() + expire_timeout / 1000.0
@@ -80,9 +79,9 @@ class RoficationDbusObject(service.Object):
 
 
 class RoficationDbusService:
-    def __init__(self, queue: NotificationQueue, datetime_format: str = None) -> None:
+    def __init__(self, queue: NotificationQueue) -> None:
         # preserve D-Bus object reference
-        self._object = RoficationDbusObject(queue, datetime_format)
+        self._object = RoficationDbusObject(queue)
         # create GLib mainloop, this is needed to make D-Bus work and takes care of catching signals.
         self._loop = MainLoop()
 

--- a/rofication/_gui.py
+++ b/rofication/_gui.py
@@ -36,8 +36,8 @@ def rofi_entry(notification: Notification) -> str:
     stripped_summ = strip_tags(notification.summary)
     stripped_app = strip_tags(notification.application)
     stripped_body = strip_tags(' '.join(notification.body.split()))
-    stripped_timestamp = strip_tags (notification.timestamp) if notification.timestamp else ""
-    return f'<b>{stripped_timestamp} {stripped_summ}</b> <small>({stripped_app})</small>\n<small>{stripped_body}</small>'
+    stripped_timestamp = f"{strip_tags (notification.timestamp)} " if notification.timestamp else ""
+    return f'<b>{stripped_timestamp}{stripped_summ}</b> <small>({stripped_app})</small>\n<small>{stripped_body}</small>'
 
 
 def call_rofi(entries: Iterable[str], additional_args: List[str] = None) -> (int, int):

--- a/rofication/_gui.py
+++ b/rofication/_gui.py
@@ -36,7 +36,8 @@ def rofi_entry(notification: Notification) -> str:
     stripped_summ = strip_tags(notification.summary)
     stripped_app = strip_tags(notification.application)
     stripped_body = strip_tags(' '.join(notification.body.split()))
-    return f'<b>{stripped_summ}</b> <small>({stripped_app})</small>\n<small>{stripped_body}</small>'
+    stripped_timestamp = strip_tags (notification.timestamp) if notification.timestamp else ""
+    return f'<b>{stripped_timestamp} {stripped_summ}</b> <small>({stripped_app})</small>\n<small>{stripped_body}</small>'
 
 
 def call_rofi(entries: Iterable[str], additional_args: List[str] = None) -> (int, int):

--- a/rofication/_gui.py
+++ b/rofication/_gui.py
@@ -2,11 +2,13 @@ import re
 import struct
 import subprocess
 from typing import Iterable, List
+from datetime import datetime
 
 from gi.repository import GLib
 
 from ._client import RoficationClient
 from ._notification import Urgency, Notification
+from ._util import Resource
 
 HTML_TAGS_PATTERN = re.compile(r'<[^>]*?>')
 
@@ -32,13 +34,12 @@ def strip_tags(value: str) -> str:
     return GLib.markup_escape_text(HTML_TAGS_PATTERN.sub('', value))
 
 
-def rofi_entry(notification: Notification) -> str:
+def rofi_entry(notification: Notification, tsformat: str) -> str:
     stripped_summ = strip_tags(notification.summary)
     stripped_app = strip_tags(notification.application)
     stripped_body = strip_tags(' '.join(notification.body.split()))
-    stripped_timestamp = f"{strip_tags (notification.timestamp)} " if notification.timestamp else ""
-    return f'<b>{stripped_timestamp}{stripped_summ}</b> <small>({stripped_app})</small>\n<small>{stripped_body}</small>'
-
+    formatted_ts = f"{datetime.fromtimestamp(notification.timestamp).strftime(tsformat)} " if tsformat else ""
+    return f'<b>{formatted_ts}{stripped_summ}</b> <small>({stripped_app})</small>\n<small>{stripped_body}</small>'
 
 def call_rofi(entries: Iterable[str], additional_args: List[str] = None) -> (int, int):
     command = ROFI_COMMAND
@@ -64,6 +65,7 @@ def call_rofi(entries: Iterable[str], additional_args: List[str] = None) -> (int
 class RoficationGui():
     def __init__(self, client: RoficationClient = None):
         self._client: RoficationClient = RoficationClient() if client is None else client
+        self._tsformat = Resource(env_name='i3xrocks_notify_timestamp_format', xres_name='i3xrocks.notify.timestamp.format', default='').fetch()
 
     def run(self) -> None:
         selected = 0
@@ -77,7 +79,7 @@ class RoficationGui():
             # reassigns indices of notifications
             for index, notification in enumerate(self._client.list()):
                 notifications.append(notification)
-                entries.append(rofi_entry(notification))
+                entries.append(rofi_entry(notification, self._tsformat))
                 if notification.urgency == Urgency.CRITICAL:
                     urgent.append(str(index))
                 if notification.urgency == Urgency.LOW:

--- a/rofication/_notification.py
+++ b/rofication/_notification.py
@@ -23,6 +23,7 @@ class Notification:
         self.application: Optional[str] = None
         self.urgency: Urgency = Urgency.NORMAL
         self.actions: Sequence[str] = ()
+        self.hints: Mapping[str, any] = {}
         self.timestamp = None
 
     def asdict(self) -> Mapping[str, any]:
@@ -38,5 +39,6 @@ class Notification:
         notification.application = dct.get('application')
         notification.urgency = Urgency(dct.get('urgency', Urgency.NORMAL))
         notification.actions = tuple(dct.get('actions', ()))
+        notification.hints = mapping(dct.get('hints'))
         notification.timestamp = dct.get('timestamp', '')
         return notification

--- a/rofication/_notification.py
+++ b/rofication/_notification.py
@@ -1,7 +1,6 @@
 from enum import IntEnum
 from typing import Sequence, Optional, Mapping
 
-
 class Urgency(IntEnum):
     LOW = 0
     NORMAL = 1
@@ -24,6 +23,7 @@ class Notification:
         self.application: Optional[str] = None
         self.urgency: Urgency = Urgency.NORMAL
         self.actions: Sequence[str] = ()
+        self.timestamp = None
 
     def asdict(self) -> Mapping[str, any]:
         return {field: value for field, value in vars(self).items() if value is not None}
@@ -38,4 +38,5 @@ class Notification:
         notification.application = dct.get('application')
         notification.urgency = Urgency(dct.get('urgency', Urgency.NORMAL))
         notification.actions = tuple(dct.get('actions', ()))
+        notification.timestamp = dct.get('timestamp', '')
         return notification


### PR DESCRIPTION
I find it a bit annoying that when I open the notification app I just get a list of notifications but no clue about when each arrived so this small PR solves that.

Note - timestamp format is currently hardcoded. We probably want to make it configurable, but it doesn't seem like there's a config file that reaches this code so unsure about the best way to go about it.
