### PR TITLE
Add command to delete list of notifications by id

### DIFF
--- a/rofication/_client.py
+++ b/rofication/_client.py
@@ -29,6 +29,9 @@ class RoficationClient:
     def delete(self, nid: int) -> None:
         self._send('del', nid)
 
+    def delete_multi(self, ids: str) -> None:
+            self._send('delm', ids)
+
     def delete_all(self, application: str) -> None:
         self._send('dela', application)
 

--- a/rofication/_server.py
+++ b/rofication/_server.py
@@ -31,6 +31,11 @@ class RoficationRequestHandler(BaseRequestHandler):
         with self.server.queue.lock:
             self.server.queue.remove(nid)
 
+    def delete_multi(self, ids: str) -> None:
+        with self.server.queue.lock:
+            to_remove = [int(i) for i in ids.split(',')]
+            self.server.queue.remove_all(to_remove)
+
     def delete_all(self, application: str) -> None:
         with self.server.queue.lock:
             to_remove = [n.id for n in self.server.queue
@@ -57,6 +62,9 @@ class RoficationRequestHandler(BaseRequestHandler):
             elif cmd == 'del':
                 # dismiss an item.
                 self.delete(nid=int(args[0]))
+            elif cmd == 'delm':
+                # dismiss list of notifications.
+                self.delete_multi(ids=args[0])
             elif cmd == 'dela':
                 # dismiss all items from an application.
                 self.delete_all(application=args[0])


### PR DESCRIPTION
I am working on a new front end that allows to bulk-delete notifications and am getting socket connect races when deleting each individually.  Adding this command allows me to delete all with one socket connect. 

## Testing done
* run notification w test data of notifications
* connect to server via nc: `nc -U /tmp/rofi_notification_daemon`
* send `delm:1,2,3' to server
* observe output from dameon listing notifications deleted
* send `list` to server, check that deleted ids are not returned
