### PR TITLE
Display oldest notifications first by default

### DIFF
--- a/rofication/_server.py
+++ b/rofication/_server.py
@@ -7,7 +7,7 @@ from typing import TextIO
 from ._notification import Urgency, Notification
 from ._queue import NotificationQueue
 from ._static import ROFICATION_UNIX_SOCK
-
+from rofication import resources
 
 class ThreadedUnixStreamServer(ThreadingMixIn, UnixStreamServer):
     def start(self) -> threading.Thread:
@@ -44,7 +44,10 @@ class RoficationRequestHandler(BaseRequestHandler):
 
     def list(self, fp: TextIO) -> None:
         with self.server.queue.lock:
-            json.dump(list(self.server.queue), fp, default=Notification.asdict)
+            messages = list(self.server.queue)
+            if resources.oldest_first.fetch() != 'true':
+                messages.reverse()
+            json.dump(messages, fp, default=Notification.asdict)
 
     def see(self, nid: int) -> None:
         with self.server.queue.lock:

--- a/rofication/_server.py
+++ b/rofication/_server.py
@@ -3,7 +3,6 @@ import os
 import threading
 from socketserver import ThreadingMixIn, UnixStreamServer, BaseRequestHandler
 from typing import TextIO
-from operator import itemgetter
 
 from ._notification import Urgency, Notification
 from ._queue import NotificationQueue

--- a/rofication/resources/__init__.py
+++ b/rofication/resources/__init__.py
@@ -1,2 +1,2 @@
 from ._static import __version__, value_font, notify_some, notify_none, notify_error, \
-    value_color, label_color, critical_color, nominal_color, warning_color
+    value_color, label_color, critical_color, nominal_color, warning_color, oldest_first

--- a/rofication/resources/__init__.py
+++ b/rofication/resources/__init__.py
@@ -1,2 +1,2 @@
 from ._static import __version__, value_font, notify_some, notify_none, notify_error, \
-    value_color, label_color, critical_color, nominal_color, warning_color, oldest_first
+    value_color, label_color, critical_color, nominal_color, warning_color, notify_sort_by

--- a/rofication/resources/_static.py
+++ b/rofication/resources/_static.py
@@ -8,7 +8,7 @@ value_font = Resource(env_name='font', xres_name='i3xrocks.value.font', default=
 notify_none = Resource(env_name='i3xrocks_label_notify_none', xres_name='i3xrocks.label.notify.none', default='N')
 notify_some = Resource(env_name='i3xrocks_label_notify_some', xres_name='i3xrocks.label.notify.some', default='N')
 notify_error = Resource(env_name='i3xrocks_label_notify_error', xres_name='i3xrocks.label.notify.error', default='N')
-oldest_first = Resource(env_name='i3xrocks_oldest_first', xres_name='i3xrocks.oldest.first', default='false')
+notify_sort_by = Resource(env_name='i3xrocks_notify_sort_by', xres_name='i3xrocks.notify.sort.by', default='!timestamp')
 
 value_color = Resource(env_name='color', xres_name='i3xrocks.value.color', default='#E6E1CF')
 label_color = Resource(env_name='label_color', xres_name='i3xrocks.label.color', default='#E6E1CF')

--- a/rofication/resources/_static.py
+++ b/rofication/resources/_static.py
@@ -8,6 +8,7 @@ value_font = Resource(env_name='font', xres_name='i3xrocks.value.font', default=
 notify_none = Resource(env_name='i3xrocks_label_notify_none', xres_name='i3xrocks.label.notify.none', default='N')
 notify_some = Resource(env_name='i3xrocks_label_notify_some', xres_name='i3xrocks.label.notify.some', default='N')
 notify_error = Resource(env_name='i3xrocks_label_notify_error', xres_name='i3xrocks.label.notify.error', default='N')
+oldest_first = Resource(env_name='i3xrocks_oldest_first', xres_name='i3xrocks.oldest.first', default='false')
 
 value_color = Resource(env_name='color', xres_name='i3xrocks.value.color', default='#E6E1CF')
 label_color = Resource(env_name='label_color', xres_name='i3xrocks.label.color', default='#E6E1CF')


### PR DESCRIPTION
In response to https://github.com/regolith-linux/regolith-desktop/issues/607 I changed rofication-daemon to reverse notification list order (to display the newest notification first) by default.

Previous behaviour (oldest notification first) can be restored by setting `i3xrocks.oldest.first` to `true` in Xresources.