### PR TITLE
Add automatic backup of the queue. Also, signal handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ __pycache__
 .idea
 venv
 not.json
+nohup.out

--- a/rofication-daemon
+++ b/rofication-daemon
@@ -4,17 +4,30 @@ import os
 import signal
 from pathlib import Path
 from rofication import RoficationServer, NotificationQueue, RoficationDbusService
+from rofication._util import Resource
 
-if __name__ == '__main__':
-    queue_dir = os.path.expanduser('~/.cache/rofication')
+if __name__ == "__main__":
+    queue_dir = os.path.expanduser("~/.cache/rofication")
     Path(queue_dir).mkdir(parents=True, exist_ok=True)
 
     queue_file = os.path.join(queue_dir, "notifications.json")
     not_queue = NotificationQueue.load(queue_file)
-    service = RoficationDbusService(not_queue)
+
+    try:
+        save_interval = int(
+            Resource(
+                env_name="rofication_savetodisk_format",
+                xres_name="rofication.savetodisk.format",
+                default="0",
+            ).fetch()
+        )
+    except ValueError:
+        save_interval = 0
+
+    service = RoficationDbusService(not_queue, save_interval)
 
     def sigterm_handler(sig, frame):
-        print ("SIGTERM received, terminating.")
+        print("SIGTERM received, terminating.")
         not_queue.save_if_dirty()
         service.quit()
 

--- a/rofication-daemon
+++ b/rofication-daemon
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import os
+import signal
 from pathlib import Path
 from rofication import RoficationServer, NotificationQueue, RoficationDbusService
 
@@ -12,6 +13,13 @@ if __name__ == '__main__':
     not_queue = NotificationQueue.load(queue_file)
     service = RoficationDbusService(not_queue)
 
+    def sigterm_handler(sig, frame):
+        print ("SIGTERM received, terminating.")
+        not_queue.save_if_dirty()
+        service.quit()
+
+    signal.signal(signal.SIGTERM, sigterm_handler)
+
     with RoficationServer(not_queue) as server:
         server.start()
         try:
@@ -19,4 +27,4 @@ if __name__ == '__main__':
         except:
             server.shutdown()
 
-    not_queue.save(queue_file)
+    not_queue.save()

--- a/rofication/_dbus.py
+++ b/rofication/_dbus.py
@@ -90,15 +90,17 @@ class RoficationDbusObject(service.Object):
 
 
 class RoficationDbusService:
-    def __init__(self, queue: NotificationQueue) -> None:
+    def __init__(self, queue: NotificationQueue, save_interval) -> None:
         # preserve D-Bus object reference
         self.queue = queue
+        self.save_interval = save_interval
         self._object = RoficationDbusObject(queue)
         # create GLib mainloop, this is needed to make D-Bus work and takes care of catching signals.
         self._loop = MainLoop()
 
     def run(self) -> None:
-        timeout_add_seconds(60, self.backup_queue)
+        if self.save_interval > 0:
+            timeout_add_seconds(self.save_interval, self.backup_queue)
         self._loop.run()
 
     def quit(self) -> None:

--- a/rofication/_queue.py
+++ b/rofication/_queue.py
@@ -8,15 +8,21 @@ from warnings import warn
 from ._notification import Notification, CloseReason, Urgency
 from ._util import Event
 
-ALLOWED_TO_EXPIRE = ('notify-send',)
-SINGLE_NOTIFICATION_APPS = ('VLC media player',)
+ALLOWED_TO_EXPIRE = ("notify-send",)
+SINGLE_NOTIFICATION_APPS = ("VLC media player",)
 
 
 class NotificationQueue:
-    def __init__(self, mapping: Mapping[int, Notification] = None) -> None:
+    def __init__(
+        self, mapping: Mapping[int, Notification] = None, queue_file: str = None
+    ) -> None:
         self._lock = threading.Lock()
         self._last_id: int = max(mapping.keys()) + 1 if mapping else 1
-        self._mapping: MutableMapping[int, Notification] = {} if mapping is None else dict(mapping)
+        self._mapping: MutableMapping[int, Notification] = (
+            {} if mapping is None else dict(mapping)
+        )
+        self._queue_file = queue_file
+        self._dirty = False
         self.notification_seen = Event()
         self.notification_closed = Event()
 
@@ -30,31 +36,43 @@ class NotificationQueue:
     def lock(self) -> threading.Lock:
         return self._lock
 
-    def save(self, filename: str) -> None:
+    def save(self, filename: str = None) -> None:
+        if not filename:
+            filename = self._queue_file
+
+        if not filename:
+            warn("Unable to save notification queue, no file specified")
+            return
         try:
-            print('Saving notification queue to file')
-            with open(filename, 'w') as f:
+            print(f"Saving notification queue to file: {filename}")
+            with open(filename, "w") as f:
                 json.dump(list(self._mapping.values()), f, default=Notification.asdict)
+            self._dirty = False
         except:
-            warn('Failed to save notification queue')
+            warn(f"Failed to save notification queue: {filename}")
             if os.path.exists(filename):
                 os.unlink(filename)
 
+    def save_if_dirty(self) -> None:
+        if self._dirty:
+            self.save()
+
     def see(self, nid: int) -> None:
         if nid in self._mapping:
-            print(f'Seeing: {nid}')
+            print(f"Seeing: {nid}")
             notification = self._mapping[nid]
             notification.urgency = Urgency.NORMAL
             self.notification_seen.notify(notification)
             return
-        warn(f'Unable to find notification {nid}')
+        warn(f"Unable to find notification {nid}")
 
     def remove(self, nid: int) -> None:
         if nid in self._mapping:
-            print(f'Removing: {nid}')
+            print(f"Removing: {nid}")
             del self._mapping[nid]
+            self._dirty = True
             return
-        warn(f'Unable to find notification {nid}')
+        warn(f"Unable to find notification {nid}")
 
     def remove_all(self, nids: Iterable[int]) -> None:
         for nid in nids:
@@ -62,48 +80,61 @@ class NotificationQueue:
 
     def put(self, notification: Notification) -> None:
         to_replace: Optional[int]
+        self._dirty = True
+
         if notification.application in SINGLE_NOTIFICATION_APPS:
             # replace notification for applications that only allow one
-            to_replace = next((ntf.id for ntf in self._mapping.values()
-                               if ntf.application == notification.application), None)
+            to_replace = next(
+                (
+                    ntf.id
+                    for ntf in self._mapping.values()
+                    if ntf.application == notification.application
+                ),
+                None,
+            )
         else:
             # cannot have two notifications with the same ID
             to_replace = notification.id if notification.id in self._mapping else None
 
         if to_replace:
             notification.id = to_replace
-            print(f'Replacing: {notification.id}')
+            print(f"Replacing: {notification.id}")
             self._mapping[notification.id] = notification
             return
 
         notification.id = self._last_id
         self._last_id += 1
-        print(f'Adding: {notification.id}')
+        print(f"Adding: {notification.id}")
         self._mapping[notification.id] = notification
 
     def cleanup(self) -> None:
         now = time.time()
-        to_remove = [ntf.id for ntf in self._mapping.values()
-                     if ntf.deadline and ntf.deadline < now
-                     and ntf.application in ALLOWED_TO_EXPIRE]
+        to_remove = [
+            ntf.id
+            for ntf in self._mapping.values()
+            if ntf.deadline
+            and ntf.deadline < now
+            and ntf.application in ALLOWED_TO_EXPIRE
+        ]
         if to_remove:
-            print(f'Expired: {to_remove}')
+            print(f"Expired: {to_remove}")
+            self._dirty = True
             for nid in to_remove:
                 self.notification_closed.notify(self._mapping[nid], CloseReason.EXPIRED)
                 del self._mapping[nid]
 
     @classmethod
-    def load(cls, filename: str) -> 'NotificationQueue':
+    def load(cls, filename: str) -> "NotificationQueue":
         if not os.path.exists(filename):
-            print('Creating empty notification queue')
-            return cls({})
+            print("Creating empty notification queue")
+            return cls({}, filename)
 
         try:
-            print('Loading notification queue from file')
-            with open(filename, 'r') as f:
+            print(f"Loading notification queue from file: {filename}")
+            with open(filename, "r") as f:
                 mapping = {n.id: n for n in json.load(f, object_hook=Notification.make)}
         except:
-            warn('Failed to load notification queue')
+            warn(f"Failed to load notification queue: {filename}")
             mapping = {}
 
-        return cls(mapping)
+        return cls(mapping, filename)


### PR DESCRIPTION
Currently the queue is only saved when the program ends cleanly. But on crash, system reboot, etc, that never happens, and then system comes up with whatever we had on the queue when it was last saved.

This PR does two things:

- Capture signals, so for example SIGTERM is properly handled - we exit the GTK loop, we save the queue, we write a message.
- Make a backup of the queue every minute if needed. This could be made configurable but I don't think it's worth the trouble.

Tested by running the daemon from terminal, sending it SIGTERM, also keyboard interrupt, send notifications every few seconds to make the queue dirty and force a save, then don't send any additional notification to verify that it won't save unless needed.

Bonus: Also run black, which is why there's a few format changes in the files.
