### PR TITLE
Fix ImportError exception for Python 3.10 or higher

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,8 @@ __pycache__
 .idea
 venv
 not.json
+
+# Release
+build
+dist
+rofication.egg-info

--- a/rofication/_util.py
+++ b/rofication/_util.py
@@ -1,8 +1,11 @@
 import os
-from collections import MutableSequence, Callable
 from subprocess import check_output
 from typing import Optional
 
+try:
+    from collections.abc import MutableSequence, Callable
+except ImportError: # Python < 3.10
+    from collections import MutableSequence, Callable
 
 class Event:
     def __init__(self) -> None:

--- a/rofication/_util.py
+++ b/rofication/_util.py
@@ -1,11 +1,7 @@
 import os
+from collections.abc import MutableSequence, Callable
 from subprocess import check_output
 from typing import Optional
-
-try:
-    from collections.abc import MutableSequence, Callable
-except ImportError: # Python < 3.10
-    from collections import MutableSequence, Callable
 
 class Event:
     def __init__(self) -> None:


### PR DESCRIPTION
Python 3.10 was [recently released](https://www.python.org/downloads/release/python-3101/). If you try to install regolith-rofication with that version you will get an import error like this:

```python
...
ImportError: cannot import name 'MutableSequence' from 'collections' (/usr/lib/python3.10/collections/__init__.py)
```

This seems to happen because the abstract base classes will not be exposed as aliases in regular collections module. See https://docs.python.org/3.9/whatsnew/3.9.html

I know this will not affect to Regolith Linux installations for now but it does affect to standalone installations that want to use this new Python version.