### PR TITLE
Use xrescat in PATH

### DIFF
--- a/rofication/_util.py
+++ b/rofication/_util.py
@@ -29,7 +29,7 @@ class Resource:
 
         # avoid calling xrescat if the environment variable is set
         if env_val is None:
-            cmd = ('/usr/bin/xrescat', self.xres_name, self.default)
+            cmd = ('xrescat', self.xres_name, self.default)
             return check_output(cmd, universal_newlines=True)
         else:
             return env_val


### PR DESCRIPTION
Before this commit, `rofication/_util.py:Resource` would call the command `/usr/bin/xrescat`. After this commit, only `xrespath` is called, which should use the user's $PATH to determine the location of `xrespath`.

This change will allow for more flexible installations of `xrescat`. It will make packaging `rofication` in other linux distributions that doesn't use `/usr/bin` much easier.